### PR TITLE
Refactor standings components

### DIFF
--- a/src/components/Standings.js
+++ b/src/components/Standings.js
@@ -1,10 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { DataGrid } from "@mui/x-data-grid";
-import { useNavigate, useLocation } from "react-router-dom";
-import { getStandings } from "../services/api"; // Make sure to import your API function
+import { useNavigate } from "react-router-dom";
 import { makeStyles } from "@mui/styles";
 import { Paper, Box, Button } from "@mui/material";
-import ResetIcon from "@mui/icons-material/Restore"; // Import the Reset Icon
+import ResetIcon from "@mui/icons-material/Restore";
 
 const useStyles = makeStyles({
   dataGrid: {
@@ -40,38 +39,13 @@ const useStyles = makeStyles({
   },
 });
 
-export default function Standings() {
+export default function Standings({ standings }) {
   const classes = useStyles();
-
-  const [standings, setStandings] = useState([]);
-  const [muiTableKey, setMuiTableKey] = useState(1); // updating key will force reset/rerender of filter on DataGrid 
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-
+  const [muiTableKey, setMuiTableKey] = useState(1);
   const navigate = useNavigate();
-  const location = useLocation();
 
-  useEffect(() => {
-    const fetchStandings = async () => {
-      try {
-        const queryParams = new URLSearchParams(location.search);
-        const rosteredPlayer = queryParams.get('rostered_player');
-        const scaledFlex = queryParams.get('scaled_flex');
-        const data = await getStandings({ rostered_player: rosteredPlayer, scaled_flex: scaledFlex });
-        setStandings(data.entries);
-        setLoading(false);
-      } catch (error) {
-        setError(error);
-        setLoading(false);
-      }
-    };
-    fetchStandings();
-  }, [location.search]);
-  
-  // Increment key on DataGrid component to force a rerender 
-  // https://stackoverflow.com/questions/72810599/how-to-clear-all-applied-filters-in-mui-react-datagrid
-  const resetFilters = async () => {
-    setMuiTableKey(muiTableKey + 1); 
+  const resetFilters = () => {
+    setMuiTableKey(muiTableKey + 1);
   };
 
   const columns = [
@@ -96,22 +70,19 @@ export default function Standings() {
     { field: "total", headerName: "Total", width: 150 },
   ];
 
-  if (loading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error.message}</div>;
-
   return (
-    <Paper sx={{ p: 4, mt: 4, position : "relative" }}>
-      {/* Reset Button */}
+    <Paper sx={{ p: 4, mt: 4, position: "relative" }}>
       <Box className={classes.resetButtonContainer}>
         <Button
-            onClick={resetFilters}
-            endIcon={<ResetIcon />}
-            variant="contained"
+          onClick={resetFilters}
+          endIcon={<ResetIcon />}
+          variant="contained"
         >
           Reset Table
         </Button>
       </Box>
       <DataGrid
+        key={muiTableKey}
         rows={standings}
         columns={columns}
         pageSize={10}
@@ -122,7 +93,11 @@ export default function Standings() {
           },
         }}
         getRowClassName={(params) =>
-          params.row.is_user_entry ? classes.userRow : (params.indexRelativeToCurrentPage % 2 === 0 ? classes.evenRow : classes.oddRow)
+          params.row.is_user_entry
+            ? classes.userRow
+            : params.indexRelativeToCurrentPage % 2 === 0
+            ? classes.evenRow
+            : classes.oddRow
         }
       />
     </Paper>

--- a/src/components/StandingsPage.js
+++ b/src/components/StandingsPage.js
@@ -1,31 +1,100 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Tabs, Tab, Box, Typography, Paper } from "@mui/material";
 import Standings from "./Standings";
 import SurvivorStandings from "./SurvivorStandings";
+import { getStandings, getSurivorStandings } from "../services/api";
+import { useLocation } from "react-router-dom";
 
 export default function StandingsPage() {
-  const [selectedTab, setSelectedTab] = useState(0); // manages the selected tab
+  const [selectedTab, setSelectedTab] = useState(0);
+  const [regularStandings, setRegularStandings] = useState([]);
+  const [survivorStandings, setSurvivorStandings] = useState([]);
+  const [regularLoading, setRegularLoading] = useState(true);
+  const [survivorLoading, setSurvivorLoading] = useState(true);
+  const [regularError, setRegularError] = useState(null);
+  const [survivorError, setSurvivorError] = useState(null);
+  
+  const location = useLocation();
+
+  // fetch regular standings 
+  useEffect(() => {
+    const fetchRegularStandings = async () => {
+      try {
+        setRegularLoading(true);
+        const queryParams = new URLSearchParams(location.search);
+        const rosteredPlayer = queryParams.get('rostered_player');
+        const scaledFlex = queryParams.get('scaled_flex');
+        
+        const regularData = await getStandings({ 
+          rostered_player: rosteredPlayer, 
+          scaled_flex: scaledFlex 
+        });
+
+        setRegularStandings(regularData.entries);
+        setRegularError(null);
+      } catch (error) {
+        setRegularError(error.message);
+      } finally {
+        setRegularLoading(false);
+      }
+    };
+
+    fetchRegularStandings();
+  }, [location.search]);
+
+  // fetch survivor standings
+  useEffect(() => {
+    const fetchSurvivorStandings = async () => {
+      try {
+        setSurvivorLoading(true);
+        const queryParams = new URLSearchParams(location.search);
+        const rosteredPlayer = queryParams.get('rostered_player');
+        const scaledFlex = queryParams.get('scaled_flex');
+        
+        const survivorData = await getSurivorStandings({ 
+          rostered_player: rosteredPlayer, 
+          scaled_flex: scaledFlex 
+        });
+
+        setSurvivorStandings(survivorData.entries);
+        setSurvivorError(null);
+      } catch (error) {
+        setSurvivorError(error.message);
+      } finally {
+        setSurvivorLoading(false);
+      }
+    };
+
+    fetchSurvivorStandings();
+  }, [location.search]);
 
   const handleTabChange = (event, newValue) => {
     setSelectedTab(newValue);
   };
 
-  return (
-      <Paper sx={{ pl: 0, pr: 0, pt:4 , mt: 0, elevation : 0 }}>
-            <Typography variant="h4"
-              // center the text
-              sx={{
-                  textAlign: "center",
-                  justifyContent: "center",
+  // loading states
+  if (selectedTab === 0 && regularLoading) return <div>Loading regular standings...</div>;
+  if (selectedTab === 1 && survivorLoading) return <div>Loading survivor standings...</div>;
+  if (selectedTab === 0 && regularError) return <div>Error loading regular standings: {regularError}</div>;
+  if (selectedTab === 1 && survivorError) return <div>Error loading survivor standings: {survivorError}</div>;
 
-              }}
-              gutterBottom>
-                {selectedTab === 0 ? "Entry Standings" : "Survivor Standings"}
-            </Typography>
-      <Tabs 
-        value={selectedTab} 
-        onChange={handleTabChange} 
-        variant="fullWidth" 
+  return (
+    <Paper sx={{ pl: 0, pr: 0, pt: 4, mt: 0, elevation: 0 }}>
+      <Typography
+        variant="h4"
+        sx={{
+          textAlign: "center",
+          justifyContent: "center",
+        }}
+        gutterBottom
+      >
+        {selectedTab === 0 ? "Entry Standings" : "Survivor Standings"}
+      </Typography>
+      
+      <Tabs
+        value={selectedTab}
+        onChange={handleTabChange}
+        variant="fullWidth"
         sx={{ marginBottom: 2 }}
       >
         <Tab label="Entry Standings" />
@@ -33,7 +102,11 @@ export default function StandingsPage() {
       </Tabs>
 
       <Box>
-        {selectedTab === 0 ? <Standings /> : <SurvivorStandings />}
+        {selectedTab === 0 ? (
+          <Standings standings={regularStandings} />
+        ) : (
+          <SurvivorStandings standings={survivorStandings} />
+        )}
       </Box>
     </Paper>
   );

--- a/src/constants.js
+++ b/src/constants.js
@@ -76,7 +76,7 @@ export const isPlayoffTeamAlive = {
   WAS: true,
   KC: true,
   LAC: false,
-  DEN: true,
+  DEN: false,
   HOU: true,
   BAL: true,
   PIT: false,


### PR DESCRIPTION
refactored `Standings`, `SurvivorStandings` and `StandingsPage` components so that Standings APIs (`StandingsAPIView`, and `SurvivorStandingsAPIView`) get called via useEffect in `StandingsPage` parent component and data is passed to child standings table components as props

Removed sort feature of Position columns in Survivor Standings table (i.e. you cant sort the QB, RB1, RB2, etc. columns)

Small CSS changes to Survivor Table to make all columns fit on Desktop screens and hopefully Mobile.

Flipped Denver to false in `isPlayoffTeamAlive` map
