### PR TITLE
Elimated DET and HOU from playoffs

### DIFF
--- a/src/components/Rules.js
+++ b/src/components/Rules.js
@@ -16,16 +16,16 @@ import ScaledFlexRulesTable from "./ScaledFlexRulesTable";
 
 export default function Rules() {
   const payouts = [
-    { position: "1st", amount: "55% of pot" },
-    { position: "2nd", amount: "20% of pot" },
-    { position: "3rd", amount: "10% of pot" },
-    { position: "4th", amount: "7.5% of pot" },
-    { position: "5th", amount: "5% of pot" },
+    { position: "1st", amount: "$1650" },
+    { position: "2nd", amount: "$600" },
+    { position: "3rd", amount: "$300" },
+    { position: "4th", amount: "$225" },
+    { position: "5th", amount: "$150" },
     { position: "6th", amount: "$20" },
     { position: "7th", amount: "$20" },
     { position: "Last Place", amount: "$20" },
   ];
-
+  
   const pricing = [
     { entries: "1 entry", price: "$20" },
     { entries: "3 entries", price: "$55" },

--- a/src/constants.js
+++ b/src/constants.js
@@ -69,7 +69,7 @@ export const playoffTeams = [
 export const isPlayoffTeamAlive = {
   LAR: true,
   TB: false,
-  DET: true,
+  DET: false,
   MIN: false,
   GB: false,
   PHI: true,
@@ -77,7 +77,7 @@ export const isPlayoffTeamAlive = {
   KC: true,
   LAC: false,
   DEN: false,
-  HOU: true,
+  HOU: false,
   BAL: true,
   PIT: false,
   BUF: true,

--- a/src/constants.js
+++ b/src/constants.js
@@ -63,7 +63,7 @@ export const playoffTeams = [
   "BAL",
   "PIT",
   "BUF",
-]
+];
 
 // NOTE: Update this to update the SurvivorStandings component to show eliminated players as red in table
 export const isPlayoffTeamAlive = {
@@ -73,12 +73,12 @@ export const isPlayoffTeamAlive = {
   MIN: false,
   GB: false,
   PHI: true,
-  WAS: true,
+  WAS: false,
   KC: true,
   LAC: false,
   DEN: false,
   HOU: false,
   BAL: false,
   PIT: false,
-  BUF: true,
-}
+  BUF: false,
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -67,7 +67,7 @@ export const playoffTeams = [
 
 // NOTE: Update this to update the SurvivorStandings component to show eliminated players as red in table
 export const isPlayoffTeamAlive = {
-  LAR: true,
+  LAR: false,
   TB: false,
   DET: false,
   MIN: false,
@@ -78,7 +78,7 @@ export const isPlayoffTeamAlive = {
   LAC: false,
   DEN: false,
   HOU: false,
-  BAL: true,
+  BAL: false,
   PIT: false,
   BUF: true,
 }


### PR DESCRIPTION
- Set DET and HOU to false in `isPlayoffTeamAlive` constant 
- Updated Rules.js component to show payouts in dollars instead of %